### PR TITLE
Duplicate projects

### DIFF
--- a/src/api/v1/community_businesses/volunteers/__tests__/projects.test.integration.ts
+++ b/src/api/v1/community_businesses/volunteers/__tests__/projects.test.integration.ts
@@ -88,6 +88,19 @@ describe('API /community-businesses/me/volunteers/projects', () => {
       expect((<any> res2.result).result).toHaveLength(3);
     });
 
+    test('cannot create project with a duplicate name', async () => {
+      const res = await server.inject({
+        method: 'POST',
+        url: '/v1/community-businesses/me/volunteers/projects',
+        credentials: adminCreds,
+        payload: { name: 'Party' },
+      });
+
+      expect(res.statusCode).toBe(409);
+      expect(res.result)
+        .toEqual({ error: expect.objectContaining({ message: 'Cannot add duplicate project' }) });
+    });
+
     // General {id} routes not implemented yet, remove the 'skip' when they are
     test.skip('cannot create new project for other org', async () => {
       const res = await server.inject({
@@ -171,6 +184,21 @@ describe('API /community-businesses/me/volunteers/projects', () => {
       });
 
       expect(res.statusCode).toBe(400);
+    });
+
+    test('cannot update name to already existing name', async () => {
+      const res = await server.inject({
+        method: 'PUT',
+        url: '/v1/community-businesses/me/volunteers/projects/1',
+        credentials: adminCreds,
+        payload: {
+          name: 'Take over the world',
+        },
+      });
+
+      expect(res.statusCode).toBe(409);
+      expect(res.result)
+        .toEqual({ error: expect.objectContaining({ message: 'Project name is a duplicate' }) });
     });
 
     // General {id} routes not implemented yet, remove the 'skip' when they are

--- a/src/models/__tests__/community_business.test.integration.ts
+++ b/src/models/__tests__/community_business.test.integration.ts
@@ -120,6 +120,38 @@ describe('Community Business Model', () => {
       expect(org).toEqual(expect.objectContaining(changeset));
     });
 
+    test('add :: cannot create record using deleted region', async () => {
+      expect.assertions(2);
+      const changeset = await factory.build('communityBusiness');
+      const res = await trx('community_business_region')
+        .update({ deleted_at: new Date() })
+        .where({ region_name: changeset.region });
+
+      expect(res).toBe(1);
+
+      try {
+        await CommunityBusinesses.add(trx, changeset);
+      } catch (error) {
+        expect(error).toBeTruthy();
+      }
+    });
+
+    test('add :: cannot create record using deleted sector', async () => {
+      expect.assertions(2);
+      const changeset = await factory.build('communityBusiness');
+      const res = await trx('community_business_sector')
+        .update({ deleted_at: new Date() })
+        .where({ sector_name: changeset.sector });
+
+      expect(res).toBe(1);
+
+      try {
+        await CommunityBusinesses.add(trx, changeset);
+      } catch (error) {
+        expect(error).toBeTruthy();
+      }
+    });
+
     test('update :: modify value in local table', async () => {
       const changeset = { logoUrl: 'foo' };
       const org = await CommunityBusinesses.getOne(trx, { where: { id: 1 } });

--- a/src/models/__tests__/user.test.integration.ts
+++ b/src/models/__tests__/user.test.integration.ts
@@ -145,6 +145,57 @@ describe('User Model', () => {
       expect(passwordCheck).toBeTruthy();
     });
 
+    test('add :: cannot create record with deleted gender', async () => {
+      expect.assertions(2);
+
+      const changeset = await factory.build('volunteer');
+      const res = await trx('gender')
+        .update({ deleted_at: new Date() })
+        .where({ gender_name: changeset.gender });
+
+      expect(res).toBe(1);
+
+      try {
+        await Users.add(trx, changeset);
+      } catch (error) {
+        expect(error).toBeTruthy();
+      }
+    });
+
+    test('add :: cannot create record with deleted disability', async () => {
+      expect.assertions(2);
+
+      const changeset = await factory.build('volunteer');
+      const res = await trx('disability')
+        .update({ deleted_at: new Date() })
+        .where({ disability_name: changeset.disability });
+
+      expect(res).toBe(1);
+
+      try {
+        await Users.add(trx, changeset);
+      } catch (error) {
+        expect(error).toBeTruthy();
+      }
+    });
+
+    test('add :: cannot create record with deleted ethnicity', async () => {
+      expect.assertions(2);
+
+      const changeset = await factory.build('volunteer');
+      const res = await trx('ethnicity')
+        .update({ deleted_at: new Date() })
+        .where({ ethnicity_name: changeset.ethnicity });
+
+      expect(res).toBe(1);
+
+      try {
+        await Users.add(trx, changeset);
+      } catch (error) {
+        expect(error).toBeTruthy();
+      }
+    });
+
     test('destroy :: mark existing record as deleted', async () => {
       const users = await Users.get(trx, { where: { deletedAt: null } });
 

--- a/src/models/__tests__/volunteer_log.test.integration.ts
+++ b/src/models/__tests__/volunteer_log.test.integration.ts
@@ -380,7 +380,7 @@ describe('VolunteerLog model', () => {
     });
 
     describe('Write', () => {
-      test('addProject :: ', async () => {
+      test('addProject :: happy path', async () => {
         const cb = await CommunityBusinesses.getOne(trx, { where: { id: 1 } });
         const project = await VolunteerLogs.addProject(trx, cb, 'foo');
 
@@ -388,6 +388,19 @@ describe('VolunteerLog model', () => {
           name: 'foo',
           organisationId: 1,
         }));
+      });
+
+      test('addProject :: cannot add duplicates within CB', async () => {
+        expect.assertions(1);
+
+        const cb = await CommunityBusinesses.getOne(trx, { where: { id: 1 } });
+        await VolunteerLogs.addProject(trx, cb, 'foo');
+
+        try {
+          await VolunteerLogs.addProject(trx, cb, 'foo');
+        } catch (error) {
+          expect(error).toBeTruthy();
+        }
       });
 
       test('updateProject ::', async () => {

--- a/src/models/__tests__/volunteer_log.test.integration.ts
+++ b/src/models/__tests__/volunteer_log.test.integration.ts
@@ -216,6 +216,99 @@ describe('VolunteerLog model', () => {
       }
     });
 
+    test('add :: with valid project', async () => {
+      const now = new Date();
+
+      const res = await VolunteerLogs.add(trx, {
+        userId: 6,
+        organisationId: 2,
+        activity: 'Office support',
+        duration: { minutes: 100 },
+        project: 'Take over the world',
+        startedAt: now.toISOString(),
+      });
+
+      expect(res).toEqual(expect.objectContaining({
+        userId: 6,
+        organisationId: 2,
+        activity: 'Office support',
+        duration: { hours: 1, minutes: 40 },
+        project: 'Take over the world',
+        startedAt: now,
+      }));
+    });
+
+    test('add :: invalid project is ignored', async () => {
+      const now = new Date();
+
+      const res = await VolunteerLogs.add(trx, {
+        userId: 6,
+        organisationId: 2,
+        activity: 'Office support',
+        duration: { minutes: 100 },
+        project: 'Non-existent',
+        startedAt: now.toISOString(),
+      });
+
+      expect(res).toEqual(expect.objectContaining({
+        userId: 6,
+        organisationId: 2,
+        activity: 'Office support',
+        duration: { hours: 1, minutes: 40 },
+        startedAt: now,
+      }));
+      expect(res.project).toEqual(null);
+    });
+
+    test('add :: with duplicate deleted project', async () => {
+      const now = new Date();
+      const cb = await CommunityBusinesses.getOne(trx, { where: { id: 2 } });
+      const projects = await VolunteerLogs.getProjects(trx, cb);
+      await VolunteerLogs.deleteProject(trx, projects[0]);
+      const project = await VolunteerLogs.addProject(trx, cb, projects[0].name);
+
+      const log = await VolunteerLogs.add(trx, {
+        userId: 6,
+        organisationId: 2,
+        activity: 'Office support',
+        duration: { minutes: 100 },
+        project: project.name,
+        startedAt: now.toISOString(),
+      });
+
+      expect(log).toEqual(expect.objectContaining({
+        userId: 6,
+        organisationId: 2,
+        activity: 'Office support',
+        duration: { hours: 1, minutes: 40 },
+        project: project.name,
+        startedAt: now,
+      }));
+    });
+
+    test('add :: with deleted activity', async () => {
+      expect.assertions(2);
+      const now = new Date();
+
+      const res = await trx('volunteer_activity')
+        .update({ deleted_at: now })
+        .where({ volunteer_activity_name: 'Office support' });
+
+      expect(res).toBe(1);
+
+      try {
+        await VolunteerLogs.add(trx, {
+          userId: 6,
+          organisationId: 2,
+          activity: 'Office support',
+          duration: { minutes: 100 },
+          startedAt: now.toISOString(),
+        });
+      } catch (error) {
+        expect(error).toBeTruthy();
+      }
+    });
+
     test('update :: non-foreign key column', async () => {
       const log = await VolunteerLogs.getOne(trx, { where: { activity: 'Office support' } });
       const changes = { duration: { hours: 1, minutes: 1 } };

--- a/src/models/community_business.ts
+++ b/src/models/community_business.ts
@@ -58,6 +58,7 @@ const optionalFields: Dictionary<string> = {
   frontlineApiKey: 'frontline_account.frontline_api_key',
   frontlineWorkspaceId: 'frontline_account.frontline_workspace_id',
 };
+
 /*
  * Helpers
  */
@@ -66,12 +67,12 @@ const transformForeignKeysToSubQueries = (client: Knex | Knex.QueryBuilder) => e
     client
       .table('community_business_region')
       .select('community_business_region_id')
-      .where({ region_name: v }),
+      .where({ region_name: v, deleted_at: null }),
   'community_business.community_business_sector_id': (v: string) =>
     client
       .table('community_business_sector')
       .select('community_business_sector_id')
-      .where({ sector_name: v }),
+      .where({ sector_name: v, deleted_at: null }),
 });
 
 const dropUnwhereableCbFields = omit([

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -66,11 +66,11 @@ const replaceConstantsWithForeignKeys = renameKeys({
 
 const transformForeignKeysToSubQueries = (client: Knex) => evolve({
   gender_id: (v: string) =>
-    client('gender').select('gender_id').where({ gender_name: v }),
+    client('gender').select('gender_id').where({ gender_name: v, deleted_at: null }),
   disability_id: (v: string) =>
-    client('disability').select('disability_id').where({ disability_name: v }),
+    client('disability').select('disability_id').where({ disability_name: v, deleted_at: null }),
   ethnicity_id: (v: string) =>
-    client('ethnicity').select('ethnicity_id').where({ ethnicity_name: v }),
+    client('ethnicity').select('ethnicity_id').where({ ethnicity_name: v, deleted_at: null }),
 });
 
 const dropUnwhereableUserFields = omit([

--- a/src/models/volunteer_log.ts
+++ b/src/models/volunteer_log.ts
@@ -302,7 +302,7 @@ export const VolunteerLogs: VolunteerLogCollection = {
       ]);
 
       if (exists) {
-        throw new Error(`Project name ${project.name} is a duplicate`);
+        throw new Error(`Project name is a duplicate`);
       }
     }
 

--- a/src/models/volunteer_log.ts
+++ b/src/models/volunteer_log.ts
@@ -262,6 +262,16 @@ export const VolunteerLogs: VolunteerLogCollection = {
   },
 
   async addProject (client, cb, name) {
+    const { rows: [{ exists }] } = await client.raw('SELECT EXISTS ?', [
+      client('volunteer_project')
+        .select()
+        .where({ organisation_id: cb.id, deleted_at: null, volunteer_project_name: name }),
+    ]);
+
+    if (exists) {
+      throw new Error('Cannot add duplicate project');
+    }
+
     const [project] = await client('volunteer_project')
       .insert({
         organisation_id: cb.id,

--- a/src/models/volunteer_log.ts
+++ b/src/models/volunteer_log.ts
@@ -290,6 +290,22 @@ export const VolunteerLogs: VolunteerLogCollection = {
   },
 
   async updateProject (client, project, changeset) {
+    if (changeset.name) {
+      const { rows: [{ exists }] } = await client.raw('SELECT EXISTS ?', [
+        client('volunteer_project')
+          .select()
+          .where({
+            organisation_id: project.organisationId,
+            deleted_at: null,
+            volunteer_project_name: changeset.name,
+          }),
+      ]);
+
+      if (exists) {
+        throw new Error(`Project name ${project.name} is a duplicate`);
+      }
+    }
+
     return client('volunteer_project')
       .update(filter((a) => typeof a !== 'undefined', {
         volunteer_project_name: changeset.name,

--- a/src/models/volunteer_log.ts
+++ b/src/models/volunteer_log.ts
@@ -47,12 +47,12 @@ const transformForeignKeysToSubQueries = (client: Knex, org_id: number) => evolv
   'volunteer_hours_log.volunteer_activity_id': (s: string) =>
     client('volunteer_activity')
       .select('volunteer_activity_id')
-      .where({ volunteer_activity_name: s }),
+      .where({ volunteer_activity_name: s, deleted_at: null }),
 
   'volunteer_hours_log.volunteer_project_id': (s: string) =>
     s && client('volunteer_project')
       .select('volunteer_project_id')
-      .where({ volunteer_project_name: s, organisation_id: org_id }),
+      .where({ volunteer_project_name: s, organisation_id: org_id, deleted_at: null }),
 });
 
 const transformDuration = evolve({


### PR DESCRIPTION
Related to TwinePlatform/twine-api#65

### Changes
* Prevent trying to set FK refs to columns that are soft deleted
* Prevent adding duplicate projects within a CB