### PR TITLE
🐛 fix getVisitActivityById - grab activities without catagories

### DIFF
--- a/src/models/community_business.ts
+++ b/src/models/community_business.ts
@@ -339,7 +339,7 @@ export const CommunityBusinesses: CommunityBusinessCollection = {
 
   async getVisitActivityById (client, cb, id) {
     const [visitActivity] = await client('visit_activity')
-        .innerJoin(
+        .leftOuterJoin(
           'visit_activity_category',
           'visit_activity_category.visit_activity_category_id',
           'visit_activity.visit_activity_category_id')


### PR DESCRIPTION
- replace inner join with left outer join

relates TwinePlatform/twine-visitor#607 - note not fixing as there may also be issues with old user accounts

🚨 **SELF MERGING due to app breaking bug** 🚨