### PR TITLE
✨ add script to fetch papertrail logs

### DIFF
--- a/bin/fetch_papertrail_logs.sh
+++ b/bin/fetch_papertrail_logs.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+#
+# Use to download archived logs from papertrail between two dates
+#
+# Usage
+#  $ ./bin/fetch_papertrail_logs.sh [from] [to] [output_file]
+#
+# Arguments
+#  from - YYYY-MM-DD date string; lower date limit for log retrieval
+#
+#  to - YYYY-MM-DD date string; upper date limit for log retrieval
+#
+#  output_file - filepath in which to dump the contents of the logs
+#
+# Environment
+#  PAPERTRAIL_API_TOKEN - [required] Personal API access token for Papertrail API
+#
+# NOTES:
+# - Ensure the script has execute permissions, otherwise execute via `bash`.
+# - All *.tsv.gz files in the root directory are removed afterwards. Backup any files you wish to keep
+
+# Variables
+DATE_FROM=$1
+DATE_TO=$2
+FNAME=$3
+PWD=$(pwd)
+PATTERN="${PWD}/"*.tsv.gz
+
+# Initial checks
+if [ -z "${PAPERTRAIL_API_TOKEN}" ]; then
+  echo "Set the environment variable 'PAPERTRAIL_API_TOKEN'"
+  echo "The API token can be found in the profile page of your Papertrail account"
+  exit 1
+fi
+
+if [ -z "${FNAME}" ]; then
+  echo "Output filename not supplied"
+  exit 1
+fi
+
+# User notice
+echo "Using ${PAPERTRAIL_API_TOKEN}"
+echo "Fetching logs between ${DATE_FROM} and ${DATE_TO}"
+echo "Dumping logs to ${FNAME} in $(pwd)"
+
+# Fetch log manifest, parse for requested dates, generate new requests
+curl -sH "X-Papertrail-Token: ${PAPERTRAIL_API_TOKEN}" https://papertrailapp.com/api/v1/archives.json |
+  grep -o '"filename":"[^"]*"' | egrep -o '[0-9-]+' |
+  awk '$0 >= "'${DATE_FROM}'" && $0 < "'${DATE_TO}'" {
+    print "output " $0 ".tsv.gz"
+    print "url https://papertrailapp.com/api/v1/archives/" $0 "/download"
+  }' | curl --progress-bar -fLH "X-Papertrail-Token: ${PAPERTRAIL_API_TOKEN}" -K-
+
+# Unzip and concatenate downloaded files into output file
+for f in *.tsv.gz; do
+  gunzip -c "${f}" > ${FNAME};
+done
+
+# Remove zipped files
+rm *.tsv.gz

--- a/bin/strip_logs.ts
+++ b/bin/strip_logs.ts
@@ -1,0 +1,50 @@
+/*
+ * Strip down logs to important information
+ *
+ * Intended to be useful in conjunction with "fetch_papertrail_logs.sh"
+ *
+ * Usage:
+ *  npm run exc ./bin/strip_logs.ts < cat FILENAME
+ *
+ * Accepts no arguments, input taken from stdin.
+ * Use pipe (|) or redirection (<) to provide input.
+ */
+import { evolve, compose, omit, pick } from 'ramda';
+import { Stream } from 'stream';
+
+
+const readStreamToMem = (s: Stream): Promise<string> =>
+  new Promise((resolve, reject) => {
+    let data = '';
+    s.on('data', (chunk) => { data += chunk; });
+    s.on('end', () => resolve(data));
+    s.on('error', reject);
+  });
+
+
+(async () => {
+  process.stdin.resume();
+  process.stdin.setEncoding('utf8');
+
+  const fileContents = await readStreamToMem(process.stdin);
+
+  const logs = fileContents
+    .split('\n')                                            // split by line
+    .filter((l) => l.includes('app/web.1	{'))              // ignore heroku router logs
+    .map((l) => l.split('app/web.1	').slice(-1)[0].trim()) // get body of log
+    .filter((l) => l.length > 0)                            // cheap filter for something parse-able
+    .map((l) => JSON.parse(l))                              // parse the JSON
+    .sort((a, b) => a.time - b.time)                        // sort by timestamp
+    .map(compose(                                           // choose only useful properties
+      evolve({
+        time: (s) => new Date(s),
+        req: pick(['method', 'url', 'sessionUserId', 'sessionOrgId']),
+        res: omit(['headers']),
+      }),
+      pick(['time', 'req', 'res', 'payload'])
+    ))
+    .map((s) => JSON.stringify(s))                          // transform back to strings
+    .join('\n');                                            // insert new-lines
+
+  console.log(logs);
+})();


### PR DESCRIPTION
So they can be parsed and manipulated locally instead of via the Papertrail interface (sometimes that's easier).

This is mostly adapted from a code snippet in Papertrail's own docs (see https://help.papertrailapp.com/kb/how-it-works/permanent-log-archives/#download-a-large-number-of-archives).