### PR TITLE
🚀 DEPLOYMENT 30-01-19

### DIFF
--- a/src/api/v1/community_businesses/__tests__/register.test.integration.ts
+++ b/src/api/v1/community_businesses/__tests__/register.test.integration.ts
@@ -1,0 +1,118 @@
+import * as Hapi from 'hapi';
+import * as Knex from 'knex';
+import { init } from '../../../../server';
+import { getConfig } from '../../../../../config';
+import { Organisation, Organisations, User, Users, CommunityBusinesses } from '../../../../models';
+import { getTrx } from '../../../../../tests/utils/database';
+import { StandardCredentials } from '../../../../auth/strategies/standard';
+import { RegionEnum, SectorEnum } from '../../../../models/types';
+import { Roles, RoleEnum } from '../../../../auth';
+
+
+describe('PUT /community-businesses', () => {
+  let server: Hapi.Server;
+  let knex: Knex;
+  let trx: Knex.Transaction;
+
+  let admin: User;
+  let adminCreds: Hapi.AuthCredentials;
+  let organisation: Organisation;
+  const config = getConfig(process.env.NODE_ENV);
+
+  beforeAll(async () => {
+    server = await init(config);
+    knex = server.app.knex;
+
+    server.app.EmailService = {
+      send: () => Promise.resolve({
+        To: '',
+        SubmittedAt: '',
+        MessageID: '',
+        ErrorCode: 0,
+        Message: '',
+      }),
+      sendBatch: () => Promise.resolve([{
+        To: '',
+        SubmittedAt: '',
+        MessageID: '',
+        ErrorCode: 0,
+        Message: '',
+      }]),
+    };
+
+    organisation = await Organisations.getOne(knex, { where: { name: 'Aperture Science' } });
+    admin = await Users.getOne(knex, { where: { name: 'Big Boss' } });
+    adminCreds = await StandardCredentials.get(knex, admin, organisation);
+  });
+
+  afterAll(async () => {
+    await server.shutdown(true);
+  });
+
+  beforeEach(async () => {
+    trx = await getTrx(knex);
+    server.app.knex = trx;
+  });
+
+  afterEach(async () => {
+    await trx.rollback();
+    server.app.knex = knex;
+  });
+
+  describe('POST /community-businesses/register', () => {
+    test('SUCCESS - create CB and admin user with successful payload', async () => {
+      const res = await server.inject({
+        method: 'POST',
+        url: '/v1/community-businesses/register',
+        payload: {
+          orgName: 'Stick House',
+          region: RegionEnum.NORTH_EAST,
+          sector: SectorEnum.HOUSING,
+          postCode: 'I11 X11',
+          _360GivingId: 'XOXOBO',
+          adminName: 'Twiglet',
+          adminEmail: 'twiggie@stick.house',
+        },
+        credentials: adminCreds,
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.result).toEqual({
+        result: expect.objectContaining({
+          name: 'Stick House',
+          sector: 'Housing',
+        }),
+      });
+
+      const cbCheck = await CommunityBusinesses.getOne(trx, { where: { _360GivingId: 'XOXOBO' } });
+      const userCheck = await Users.getOne(trx, { where: { email: 'twiggie@stick.house' } });
+      const adminExists = await Roles.userHas(trx, {
+        role: RoleEnum.CB_ADMIN,
+        userId: (<any> userCheck).id,
+        organisationId: (<any> cbCheck).id,
+      });
+
+      expect(adminExists).toBeTruthy();
+    });
+
+    test('FAILURE - return error for duplicate 360 giving id', async () => {
+      const res = await server.inject({
+        method: 'POST',
+        url: '/v1/community-businesses/register',
+        payload: {
+          orgName: 'Stick House',
+          region: RegionEnum.NORTH_EAST,
+          sector: SectorEnum.HOUSING,
+          postCode: 'I11 X11',
+          _360GivingId: organisation._360GivingId,
+          adminName: 'Twiglet',
+          adminEmail: 'twiggie@stick.house',
+        },
+        credentials: adminCreds,
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect((<any> res.result).error.message).toEqual('360 Giving Id already exists');
+    });
+  });
+});

--- a/src/api/v1/community_businesses/__tests__/register.test.integration.ts
+++ b/src/api/v1/community_businesses/__tests__/register.test.integration.ts
@@ -114,5 +114,25 @@ describe('PUT /community-businesses', () => {
       expect(res.statusCode).toBe(400);
       expect((<any> res.result).error.message).toEqual('360 Giving Id already exists');
     });
+
+    test('FAILURE - return error for duplicate email', async () => {
+      const res = await server.inject({
+        method: 'POST',
+        url: '/v1/community-businesses/register',
+        payload: {
+          orgName: 'Stick House',
+          region: RegionEnum.NORTH_EAST,
+          sector: SectorEnum.HOUSING,
+          postCode: 'I11 X11',
+          _360GivingId: 'hidingFromTheWolf',
+          adminName: 'Twiglet',
+          adminEmail: admin.email,
+        },
+        credentials: adminCreds,
+      });
+
+      expect(res.statusCode).toBe(409);
+      expect((<any> res.result).error.message).toEqual('User already exists with this email');
+    });
   });
 });

--- a/src/api/v1/community_businesses/index.ts
+++ b/src/api/v1/community_businesses/index.ts
@@ -8,6 +8,7 @@ import visitLogs from './visit_logs';
 import visitLogAggregates from './visit_logs_aggregates';
 import volunteers from './volunteers';
 import volunteerLogs from './volunteer_logs';
+import register from './register';
 
 export default [
   ...get,
@@ -20,4 +21,5 @@ export default [
   ...visitLogAggregates,
   ...volunteers,
   ...volunteerLogs,
+  ...register,
 ];

--- a/src/api/v1/community_businesses/put.ts
+++ b/src/api/v1/community_businesses/put.ts
@@ -1,11 +1,10 @@
 import * as Hapi from 'hapi';
 import * as Boom from 'boom';
-import * as Joi from 'joi';
 import { has, flip } from 'ramda';
 import { CommunityBusinesses, CommunityBusiness } from '../../../models';
 import { getCommunityBusiness, isChildOrganisation } from '../prerequisites';
 import { PutCommunityBusinesssRequest } from '../types';
-import { id, response } from './schema';
+import { id, response, cbPayload } from './schema';
 
 
 const hasAny = (props: string[], o: object) => props.map(flip(has)(o));
@@ -24,18 +23,7 @@ export default [
         },
       },
       validate: {
-        payload: {
-          name: Joi.string().min(1),
-          region: Joi.string().min(1),
-          sector: Joi.string().min(1),
-          logoUrl: Joi.string().uri(),
-          address1: Joi.string().min(1),
-          address2: Joi.string().min(1),
-          townCity: Joi.string().min(1),
-          postCode: Joi.string().min(6).max(10),
-          turnoverBand: Joi.string().min(5).max(11),
-          _360GivingId: Joi.string().min(5).max(11),
-        },
+        payload: cbPayload,
       },
       response: { schema: response },
       pre: [
@@ -88,18 +76,7 @@ export default [
         params: {
           organisationId: id,
         },
-        payload: {
-          name: Joi.string().min(1),
-          region: Joi.string().min(1),
-          sector: Joi.string().min(1),
-          logoUrl: Joi.string().uri(),
-          address1: Joi.string().min(1),
-          address2: Joi.string().min(1),
-          townCity: Joi.string().min(1),
-          postCode: Joi.string().min(6).max(10),
-          turnoverBand: Joi.string().min(6).max(11),
-          _360GivingId: Joi.string().min(5).max(255),
-        },
+        payload: cbPayload,
       },
       response: { schema: response },
       pre: [

--- a/src/api/v1/community_businesses/register.ts
+++ b/src/api/v1/community_businesses/register.ts
@@ -60,10 +60,16 @@ export default [
         return Boom.forbidden('Insufficient permissions to create organisations');
       }
 
+      // Initial checks
       if (await CommunityBusinesses.exists(knex, { where: { _360GivingId } })) {
         return Boom.badRequest('360 Giving Id already exists');
       }
 
+      if (await Users.exists(knex, { where: { email: adminEmail } })) {
+        return Boom.conflict('User already exists with this email');
+      }
+
+      // Create accounts
       const { user, cb, token } = await knex.transaction(async (trx) => {
         const cb = await CommunityBusinesses.add(trx, {
           name: orgName,

--- a/src/api/v1/community_businesses/register.ts
+++ b/src/api/v1/community_businesses/register.ts
@@ -1,0 +1,97 @@
+import * as Hapi from 'hapi';
+import * as Boom from 'boom';
+import { omit } from 'ramda';
+
+import { CommunityBusinesses, Users, CbAdmins } from '../../../models';
+import { isChildOrganisation } from '../prerequisites';
+import { RegisterCommunityBusinessesRequest } from '../types';
+import { response, cbPayload } from './schema';
+import {
+  userName,
+  email,
+} from '../users/schema';
+import { EmailTemplate } from '../../../services/email/templates';
+
+export default [
+  {
+    method: 'POST',
+    path: '/community-businesses/register',
+    options: {
+      description: 'Register a new community businesses and invite admin user',
+      auth: {
+        strategy: 'standard',
+        access: {
+          scope: ['organisations_details-child:write'],
+        },
+      },
+      validate: {
+        payload: {
+          ...omit(['name'], cbPayload),
+          orgName: cbPayload.name,
+          adminName: userName.required(),
+          adminEmail: email.required(),
+        },
+      },
+      pre: [
+        { method: isChildOrganisation, assign: 'isChild', failAction: 'error' },
+      ],
+      response: { schema: response },
+    },
+    handler: async (request: RegisterCommunityBusinessesRequest, h: Hapi.ResponseToolkit) => {
+      const {
+        pre: { isChild },
+        server: { app: { knex, EmailService } },
+        payload: {
+          orgName,
+          region,
+          sector,
+          address1,
+          address2,
+          townCity,
+          postCode,
+          turnoverBand,
+          _360GivingId,
+          adminName,
+          adminEmail,
+        },
+      } = request;
+
+      if (!isChild) {
+        return Boom.forbidden('Insufficient permissions to create organisations');
+      }
+
+      if (await CommunityBusinesses.exists(knex, { where: { _360GivingId } })) {
+        return Boom.badRequest('360 Giving Id already exists');
+      }
+
+      const { user, cb, token } = await knex.transaction(async (trx) => {
+        const cb = await CommunityBusinesses.add(trx, {
+          name: orgName,
+          region,
+          sector,
+          address1,
+          address2,
+          townCity,
+          postCode,
+          turnoverBand,
+          _360GivingId,
+        });
+        const user = await CbAdmins.addWithRole(trx, cb, {
+          name: adminName,
+          email: adminEmail,
+        });
+        const { token } = await Users.createPasswordResetToken(trx, user);
+        return { user, cb, token };
+      });
+
+      await EmailService.send({
+        from: 'visitorapp@powertochange.org.uk', // this shouldn't be hardcoded
+        to: user.email,
+        templateId: EmailTemplate.CB_ADMIN_WELCOME,
+        templateModel: { name: user.name, organisation: cb.name, token, email: user.email },
+      });
+
+      return CommunityBusinesses.serialise(cb);
+    },
+  },
+] as Hapi.ServerRoute[];

--- a/src/api/v1/community_businesses/schema.ts
+++ b/src/api/v1/community_businesses/schema.ts
@@ -39,4 +39,17 @@ export const visitActivitiesPutPayload = {
   sunday: Joi.boolean(),
 };
 
+export const cbPayload = {
+  name: Joi.string().min(1),
+  region: Joi.string().min(1),
+  sector: Joi.string().min(1),
+  logoUrl: Joi.string().uri(),
+  address1: Joi.string().min(1),
+  address2: Joi.string().min(1),
+  townCity: Joi.string().min(1),
+  postCode: Joi.string().min(6).max(10),
+  turnoverBand: Joi.string().min(5).max(11),
+  _360GivingId: Joi.string().min(5),
+};
+
 export const meOrId = id.allow('me');

--- a/src/api/v1/types.ts
+++ b/src/api/v1/types.ts
@@ -7,6 +7,7 @@ import { ExternalAppCredentials } from '../../auth/strategies/external';
 import { RoleEnum } from '../../auth/types';
 import { GenderEnum, CommunityBusiness, User, CommonTimestamps, VolunteerLog } from '../../models';
 import { Omit } from '../../types/internal';
+import { RegionEnum, SectorEnum } from '../../models/types';
 
 
 declare module 'hapi' {
@@ -67,6 +68,22 @@ export interface GetCommunityBusinessRequest extends Hapi.Request {
 export interface GetCommunityBusinessesRequest extends Hapi.Request {
   query: ApiRequestQuery & {
     [k: string]: any
+  };
+}
+
+export interface RegisterCommunityBusinessesRequest extends Hapi.Request {
+  payload: {
+    orgName: string
+    region: RegionEnum
+    sector: SectorEnum
+    address1: string
+    address2: string
+    townCity: string
+    postCode: string
+    turnoverBand: string
+    _360GivingId: string
+    adminName: string
+    adminEmail: string
   };
 }
 

--- a/src/models/__tests__/community_business.test.integration.ts
+++ b/src/models/__tests__/community_business.test.integration.ts
@@ -1,10 +1,13 @@
 import * as Knex from 'knex';
+import { compare } from 'bcrypt';
 import { getConfig } from '../../../config';
 import factory from '../../../tests/utils/factory';
 import { CommunityBusinesses } from '..';
 import { getTrx } from '../../../tests/utils/database';
-import { Dictionary } from 'ramda';
+import { Dictionary, omit } from 'ramda';
 import { RegionEnum, SectorEnum } from '../types';
+import { CbAdmins } from '../cb_admin';
+import { RoleEnum, Roles } from '../../auth';
 
 
 describe('Community Business Model', () => {
@@ -150,6 +153,17 @@ describe('Community Business Model', () => {
       } catch (error) {
         expect(error).toBeTruthy();
       }
+    });
+
+    test('addWithRole :: creates a new user with role', async () => {
+      const changeset = await factory.build('cbAdmin');
+      const cb = await CommunityBusinesses.getOne(trx, { where: { name: 'Black Mesa Research' } });
+      const visitor = await CbAdmins.addWithRole(trx, cb, changeset);
+      const rolesCheck = await Roles
+       .userHas(trx, { role: RoleEnum.CB_ADMIN, userId: visitor.id, organisationId: cb.id });
+      expect(visitor).toEqual(expect.objectContaining(omit(['password'], changeset)));
+      expect(rolesCheck).toBeTruthy();
+      expect(await compare(changeset.password, visitor.password)).toBeTruthy();
     });
 
     test('update :: modify value in local table', async () => {

--- a/src/models/cb_admin.ts
+++ b/src/models/cb_admin.ts
@@ -6,6 +6,7 @@ import { CbAdminCollection } from './types';
 import { Users, ModelToColumn } from './user';
 import { RoleEnum } from '../auth/types';
 import { applyQueryModifiers } from './applyQueryModifiers';
+import { Roles } from '../auth';
 
 
 /*
@@ -58,6 +59,14 @@ export const CbAdmins: CbAdminCollection = {
 
   async add (client, user) {
     return Users.add(client, user);
+  },
+
+  async addWithRole (client, cb, user) {
+    return client.transaction(async (trx) => {
+      const newUser = await Users.add(trx, user);
+      await Roles.add(trx, { role: RoleEnum.CB_ADMIN, userId: newUser.id, organisationId: cb.id });
+      return newUser;
+    });
   },
 
   async update (client, user, changes) {

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -332,6 +332,7 @@ export type VolunteerCollection = UsersBaseCollection & {
 
 export type CbAdminCollection = UsersBaseCollection & {
   fromOrganisation: (k: Knex, q: Partial<Organisation>) => Promise<User[]>;
+  addWithRole: (k: Knex, c: CommunityBusiness, a: Partial<User>) => Promise<User>
 };
 
 export type OrganisationCollection = Collection<Organisation> & {


### PR DESCRIPTION
Changes:
- creates `cb/register`
- fix bug where you couldn't update turnover band to +70mil

Cannot be tested on hosting as there is no staging for `twine-temp-dash`

Partnered PR: TwinePlatform/twine-temp-dash#13 👻

User flow on `twine-temp-dash`
- can create a cb & admin user
- can update a cbs turnover band to +70mil